### PR TITLE
Help producing reproducible results

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ As input any color type is accepted (grayscale, rgb, palette, grayscale with alp
 - `deflateChunkSize` - chunk size used for deflating data chunks, this should be power of 2 and must not be less than 256 and more than 32*1024 (default: 32 kB)
 - `deflateLevel` - compression level for delate (default: 9)
 - `deflateStrategy` - compression strategy for delate (default: 3)
+- `deflateFactory` - deflate stream factory (default: `zlib.createDeflate`)
 - `filterType` - png filtering method for scanlines (default: -1 => auto, accepts array of numbers 0-4)
 
 

--- a/lib/packer.js
+++ b/lib/packer.js
@@ -17,6 +17,7 @@ var Packer = module.exports = function(options) {
   options.deflateChunkSize = options.deflateChunkSize || 32 * 1024;
   options.deflateLevel = options.deflateLevel != null ? options.deflateLevel : 9;
   options.deflateStrategy = options.deflateStrategy != null ? options.deflateStrategy : 3;
+  options.deflateFactory = options.deflateFactory || zlib.createDeflate;
 
   this.readable = true;
 };
@@ -37,7 +38,7 @@ Packer.prototype.pack = function(data, width, height, gamma) {
   var filteredData = filter(data, width, height, this._options);
 
   // compress it
-  var deflate = zlib.createDeflate({
+  var deflate = this._options.deflateFactory({
     chunkSize: this._options.deflateChunkSize,
     level: this._options.deflateLevel,
     strategy: this._options.deflateStrategy


### PR DESCRIPTION
For some applications (e.g. regression testing), it is useful if the same image data will always get encoded to the same PNG file, i.e. to have reproducible compression results. Since `zlib` is shipped with node.js, we have no control over its version via `npm`. To guarantee reproducible results, other libraries (like [`pako`](https://www.npmjs.com/package/pako)) could be used, with a fixed version number to guarantee consistent behavior.  This modification provides a hook to allow such usage.

In https://github.com/gagern/KaTeX/commit/eabe35279d0e01e740fbd1e1218f16aa5713282c I've already experimented with such a setup, using the following factory implementation:

```js
function deflateFactory(options) {
    var deflate = new pako.Deflate(options);
    var strm = new stream.Transform;
    var cb = null;
    var chunks = [];
    deflate.onData = function(chunk) {
        chunks.push(new Buffer(chunk));
    };
    deflate.onEnd = function(status) {
        if (status === 0) {
            strm.push(Buffer.concat(chunks));
            strm.push(null);
            cb();
        } else {
            strm.emit("error", new Error(deflate.msg));
        }
    };
    strm._transform = function(chunk, encoding, callback) {
        var n = chunk.length;
        var arr = new Uint8Array(n);
        for (var i = 0; i < n; ++i) {
            arr[i] = chunk[i];
        }
        deflate.push(arr, false);
        callback();
    };
    strm._flush = function(callback) {
        cb = callback;
        deflate.push(new Uint8Array(0), true);
    };
    return strm;
}
```

If the version of pako remains the same, this should always lead to the same binary representation of the image, with a single `IDAT` chunk since all the chunks returned by pako are concatenated and emitted in a single data event.