### PR TITLE
Remove accidentally-added "src" parameter from PNG.prototype.bitblt

### DIFF
--- a/lib/png.js
+++ b/lib/png.js
@@ -135,7 +135,7 @@ PNG.bitblt = function(src, dst, srcX, srcY, width, height, deltaX, deltaY) { // 
 };
 
 
-PNG.prototype.bitblt = function(src, dst, srcX, srcY, width, height, deltaX, deltaY) { // eslint-disable-line max-params
+PNG.prototype.bitblt = function(dst, srcX, srcY, width, height, deltaX, deltaY) { // eslint-disable-line max-params
 
   PNG.bitblt(this, dst, srcX, srcY, width, height, deltaX, deltaY);
   return this;


### PR DESCRIPTION
It looks like the extra "src" parameter for `PNG.prototype.bitblt` was (accidentally) introduced by a copy-paste operation in https://github.com/lukeapage/pngjs2/commit/bf5ae3c54e67cbf058c4536529da89f6513e3749#diff-525ff2e15c25b36ef49205346e137232R153